### PR TITLE
Prevent an error on ruby 2.5 & 2.6 where an additional argument is in…

### DIFF
--- a/lib/deprecation/method_wrappers.rb
+++ b/lib/deprecation/method_wrappers.rb
@@ -9,21 +9,32 @@ module Deprecation
 
     generated_deprecation_methods = Module.new
     method_names.each do |method_name|
-      generated_deprecation_methods.module_eval(<<-end_eval, __FILE__, __LINE__ + 1)
-        def #{method_name}(*args, **kwargs, &block)
-          Deprecation.warn(#{target_module.to_s},
-            Deprecation.deprecated_method_warning(#{target_module.to_s},
-              :#{method_name},
-              #{options[method_name].inspect}),
-            caller
-          )
-          if RUBY_VERSION < '2.7' && kwargs.empty?
-            super(*args, &block)
-          else
+      if RUBY_VERSION < '3'
+        generated_deprecation_methods.module_eval(<<-end_eval, __FILE__, __LINE__ + 1)
+          def #{method_name}(*args, &block)
+            Deprecation.warn(#{target_module.to_s},
+              Deprecation.deprecated_method_warning(#{target_module.to_s},
+                :#{method_name},
+                #{options[method_name].inspect}),
+              caller
+            )
             super
           end
-        end
-      end_eval
+          pass_keywords(:#{method_name}) if respond_to?(:pass_keywords, true)
+        end_eval
+      else
+        generated_deprecation_methods.module_eval(<<-end_eval, __FILE__, __LINE__ + 1)
+          def #{method_name}(*args, **kwargs, &block)
+            Deprecation.warn(#{target_module.to_s},
+              Deprecation.deprecated_method_warning(#{target_module.to_s},
+                :#{method_name},
+                #{options[method_name].inspect}),
+              caller
+            )
+            super
+          end
+        end_eval
+      end
     end
     target_module.prepend generated_deprecation_methods
   end

--- a/lib/deprecation/method_wrappers.rb
+++ b/lib/deprecation/method_wrappers.rb
@@ -17,7 +17,11 @@ module Deprecation
               #{options[method_name].inspect}),
             caller
           )
-          super
+          if RUBY_VERSION < '2.7' && kwargs.empty?
+            super(*args, &block)
+          else
+            super
+          end
         end
       end_eval
     end

--- a/spec/deprecation_spec.rb
+++ b/spec/deprecation_spec.rb
@@ -23,7 +23,7 @@ describe Deprecation do
     end
 
     def d
-
+      4
     end
 
     deprecation_deprecate :c, :d
@@ -57,6 +57,19 @@ describe Deprecation do
 
     it "delegates to the original" do
       expect(subject.f 9, foo: 3).to eq 7
+    end
+  end
+
+  describe "a method that takes no args" do
+    around do |example|
+      # We need to suppress the raise behavior, so we can ensure the original method is called
+      DeprecationTest.deprecation_behavior = :silence
+      example.run
+      DeprecationTest.deprecation_behavior = :raise
+    end
+
+    it "delegates to the original" do
+      expect(subject.d).to eq 4
     end
   end
 


### PR DESCRIPTION
…troduced

This can cause:
```
 ArgumentError:
   wrong number of arguments (given 1, expected 0)
```